### PR TITLE
Fix snippet spelling

### DIFF
--- a/src/SignedCodeBuilder.ts
+++ b/src/SignedCodeBuilder.ts
@@ -37,7 +37,7 @@ class SignedCodeBuilder {
 	}
 
 	/**
-	 * Add a snipet of code.
+	 * Add a snippet of code.
 	 */
 	addCode(code: string): this {
 		this.code.push(code);


### PR DESCRIPTION
## Summary
- correct typo in `SignedCodeBuilder` comment

## Testing
- `npm run lint` *(fails: Invalid option '--ignore-path')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e8a08f314832cbc342983c090cb79