### PR TITLE
Fix manual section markers in tests

### DIFF
--- a/src/__tests__/SignedCode-test.js
+++ b/src/__tests__/SignedCode-test.js
@@ -22,13 +22,13 @@ import TestModule from "TestModule";
 TestModule.someCall(24, 67);
 
 function printEverything() {
-    // <Manual-Section init-code START>
+    // <Manual-Section START init-code>
     console.log("42 is the answer!");
     // <Manual-Section END>
 }
 
 function someOtherFunction() {
-    // <Manual-Section more-code START>
+    // <Manual-Section START more-code>
     console.log("I don't know");
     // <Manual-Section END>
 }

--- a/src/__tests__/SignedCodeBuilder-test.js
+++ b/src/__tests__/SignedCodeBuilder-test.js
@@ -23,13 +23,13 @@ import TestModule from "TestModule";
 TestModule.someCall(24, 67);
 
 function printEverything() {
-    // <Manual-Section init-code START>
+    // <Manual-Section START init-code>
     console.log("42 is the answer!");
     // <Manual-Section END>
 }
 
 function someOtherFunction() {
-    // <Manual-Section more-code START>
+    // <Manual-Section START more-code>
     console.log("I don't know");
     // <Manual-Section END>
 }

--- a/src/__tests__/__snapshots__/SignedCode-test.js.snap
+++ b/src/__tests__/__snapshots__/SignedCode-test.js.snap
@@ -1,3 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`signedCode gets the manual sections 1`] = `Object {}`;
+exports[`signedCode gets the manual sections 1`] = `Object {
+  "init-code": Object {
+    "code": "\n    console.log(\"42 is the answer!\");\n    ",
+  },
+  "more-code": Object {
+    "code": "\n    console.log(\"I don't know\");\n    ",
+  },
+}`;

--- a/src/__tests__/__snapshots__/SignedCodeBuilder-test.js.snap
+++ b/src/__tests__/__snapshots__/SignedCodeBuilder-test.js.snap
@@ -51,7 +51,9 @@ let thereB = 'light';
 
 exports[`signedCodeBuilder accepts previous code 1`] = `
 "let thereA = 'light';
-// <Manual-Section START init-code>let thereD = 'light';// <Manual-Section END>
+// <Manual-Section START init-code>
+    console.log("42 is the answer!");
+    // <Manual-Section END>
 let thereB = 'light';
 "
 `;


### PR DESCRIPTION
## Summary
- update manual section marker comments in tests
- adjust SignedCode snapshot to include parsed manual sections
- update SignedCodeBuilder snapshot for previous code behavior

## Testing
- `npm test -- -u` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e8a7c553c832cacac24956f1dacdd