### PR TITLE
Update manual section test

### DIFF
--- a/src/__tests__/SignedCode-test.js
+++ b/src/__tests__/SignedCode-test.js
@@ -22,13 +22,13 @@ import TestModule from "TestModule";
 TestModule.someCall(24, 67);
 
 function printEverything() {
-    // <Manual-Section init-code START>
+    // <Manual-Section START init-code>
     console.log("42 is the answer!");
     // <Manual-Section END>
 }
 
 function someOtherFunction() {
-    // <Manual-Section more-code START>
+    // <Manual-Section START more-code>
     console.log("I don't know");
     // <Manual-Section END>
 }
@@ -73,10 +73,13 @@ describe("signedCode", () => {
 		expect(instance.getVersion()).toStrictEqual(368);
 	});
 
-	it("gets the manual sections", () => {
-		const instance = new SignedCode(signedTestCode(validChecksum));
-		expect(instance.getManualSections()).toMatchSnapshot();
-	});
+        it("gets the manual sections", () => {
+                const instance = new SignedCode(signedTestCode(validChecksum));
+                expect(instance.getManualSections()).toStrictEqual({
+                        "init-code": { code: "\n    console.log(\"42 is the answer!\");\n" },
+                        "more-code": { code: "\n    console.log(\"I don't know\");\n" },
+                });
+        });
 
 	it("resigns code", () => {
 		const instance = new SignedCode(signedTestCode(invalidChecksum));

--- a/src/__tests__/SignedCodeBuilder-test.js
+++ b/src/__tests__/SignedCodeBuilder-test.js
@@ -23,13 +23,13 @@ import TestModule from "TestModule";
 TestModule.someCall(24, 67);
 
 function printEverything() {
-    // <Manual-Section init-code START>
+    // <Manual-Section START init-code>
     console.log("42 is the answer!");
     // <Manual-Section END>
 }
 
 function someOtherFunction() {
-    // <Manual-Section more-code START>
+    // <Manual-Section START more-code>
     console.log("I don't know");
     // <Manual-Section END>
 }


### PR DESCRIPTION
## Summary
- fix manual section markers in JS test fixtures
- check manual sections explicitly instead of using a snapshot

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e8b907554832c8d8c528d17b6a09d